### PR TITLE
fix #4 "Modoboa: command UID => got more than 10000 bytes"

### DIFF
--- a/modoboa_webmail/lib/imaputils.py
+++ b/modoboa_webmail/lib/imaputils.py
@@ -19,7 +19,12 @@ from modoboa.lib.exceptions import InternalError
 from ..exceptions import ImapError, WebmailInternalError
 from .fetch_parser import parse_fetch_response
 
-# imaplib.Debug = 4
+
+# workaround for the "got more than 10000 bytes" exception. MAXLINE
+# value set to 1M, as on latest python versions.
+MAXLINE = 1000000
+if hasattr(imaplib, "_MAXLINE") and getattr(imaplib, "_MAXLINE") < MAXLINE:
+    setattr(imaplib, "_MAXLINE", MAXLINE)
 
 
 class capability(object):

--- a/modoboa_webmail/lib/imaputils.py
+++ b/modoboa_webmail/lib/imaputils.py
@@ -19,6 +19,7 @@ from modoboa.lib.exceptions import InternalError
 from ..exceptions import ImapError, WebmailInternalError
 from .fetch_parser import parse_fetch_response
 
+# imaplib.Debug = 4
 
 # workaround for the "got more than 10000 bytes" exception. MAXLINE
 # value set to 1M, as on latest python versions.


### PR DESCRIPTION
This is only a workaround.
Newest python versions (2015) will have this bug fixed : https://bugs.python.org/issue23647
