### PR TITLE
parse lists of e-mail recipients properly

### DIFF
--- a/modoboa_webmail/static/modoboa_webmail/js/webmail.js
+++ b/modoboa_webmail/static/modoboa_webmail/js/webmail.js
@@ -1140,7 +1140,7 @@ Webmail.prototype = {
         this.page_update(resp);
         if (this.options.contactListUrl) {
             this.$select = $('.selectize-contact').selectize({
-                delimiter: ';',
+                delimiter: ',',
                 valueField: 'address',
                 searchField: 'address',
                 options: [],

--- a/modoboa_webmail/validators.py
+++ b/modoboa_webmail/validators.py
@@ -8,12 +8,11 @@ from django.core.validators import validate_email
 
 class EmailListValidator(object):
 
-    """Validate a semi-comma separated list of email."""
+    """Validate a list of email."""
 
     def __call__(self, value):
         value = force_text(value)
-        emails = [email.strip() for email in value.split(";")]
-        addresses = getaddresses(emails)
+        addresses = getaddresses([value])
         [validate_email(email) for name, email in addresses]
 
 


### PR DESCRIPTION
A comma (,) is a valid separator in accordance with RFC 2822, it was Microsoft Outlook that introduced the use of semicolon (;).

getaddresses() will correctly split a string containing multiple e-mail addresses separated by a comma or semicolon.

closes #121