### PR TITLE
Attachment fixes

### DIFF
--- a/modoboa_webmail/__init__.py
+++ b/modoboa_webmail/__init__.py
@@ -11,6 +11,6 @@ try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:
     # package is not installed
-    pass
+    __version__ = '9.9.9'
 
 default_app_config = "modoboa_webmail.apps.WebmailConfig"

--- a/modoboa_webmail/forms.py
+++ b/modoboa_webmail/forms.py
@@ -267,7 +267,7 @@ class FolderForm(forms.Form):
 
 
 class AttachmentForm(forms.Form):
-    attachment = forms.FileField(label=_("Select a file"))
+    attachment = forms.FileField(label=_("Select a file"), allow_empty_file=True)
 
 
 class ParametersForm(param_forms.AdminParametersForm):

--- a/modoboa_webmail/lib/attachments.py
+++ b/modoboa_webmail/lib/attachments.py
@@ -93,7 +93,11 @@ def create_mail_attachment(attdef, payload=None):
     encoders.encode_base64(res)
     if isinstance(attdef["fname"], six.binary_type):
         attdef["fname"] = attdef["fname"].decode("utf-8")
-    res["Content-Disposition"] = build_header(attdef["fname"])
+    content_disposition = build_header(attdef["fname"])
+    if isinstance(content_disposition, six.binary_type):
+        res["Content-Disposition"] = content_disposition.decode("utf-8")
+    else:
+        res["Content-Disposition"] = content_disposition
     return res
 
 


### PR DESCRIPTION
This PR is made of three commits.

The first one is pretty straightforward. It sets `__version__` to avoid crashing in development mode with python 3.

The second one fixes a crash when uploading an attachment containing non ascii characters in its file name ( #165 ). The problem came from `rfc6266.build_header()` which returns a bytes object in this case :astonished: , making the python header builder crash. So I just decode it when it is the case.

The third one allows to upload empty attachments. I agree that there is no point in doing this, but as much as I know this is not forbidden in mail transport specifications. And the resulting error, `None`, is ... not really an error in fact :smile: 

Note that I did not test it with python 2, but there should not be any problem, these are small changes.

If these changes are accepted, may I ask for a release soon ? As I said in the bug report, I really need it to be fixed. ( Just asking, feel free to answer no if this bothers you )