### PR TITLE
Fix SuspiciousFileOperation when storing inline attachments

### DIFF
--- a/modoboa_webmail/lib/imapemail.py
+++ b/modoboa_webmail/lib/imapemail.py
@@ -220,7 +220,7 @@ class ImapEmail(Email):
             if re.search(r"\.\.", cid):
                 continue
             fname = "{}_{}".format(self.mailid, cid)
-            path = get_storage_path(fname)
+            os.path.relpath(get_storage_path(fname), settings.MEDIA_ROOT)
             params["fname"] = os.path.join(
                 settings.MEDIA_URL,
                 os.path.basename(get_storage_path("")),

--- a/modoboa_webmail/lib/imapemail.py
+++ b/modoboa_webmail/lib/imapemail.py
@@ -220,7 +220,7 @@ class ImapEmail(Email):
             if re.search(r"\.\.", cid):
                 continue
             fname = "{}_{}".format(self.mailid, cid)
-            os.path.relpath(get_storage_path(fname), settings.MEDIA_ROOT)
+            path = os.path.relpath(get_storage_path(fname), settings.MEDIA_ROOT)
             params["fname"] = os.path.join(
                 settings.MEDIA_URL,
                 os.path.basename(get_storage_path("")),


### PR DESCRIPTION
Fixes this issue: https://github.com/modoboa/modoboa-webmail/issues/278

SuspiciousFileOperation at /webmail/getmailcontent
Detected path traversal attempt in '/srv/modoboa/instance/media/webmail/9162_image001.png@01DBE4E4.70E93650'

Seems that Django will no longer accept absolute paths when storing media files, and insists on a relative path within the MEDIA_ROOT.